### PR TITLE
Correct type of connection for makeStringConnection

### DIFF
--- a/packages/bs-knex/src/KnexConfig.re
+++ b/packages/bs-knex/src/KnexConfig.re
@@ -160,7 +160,7 @@ external makeStringConnection :
     ~client: string=?,
     ~dialect: string=?,
     ~version: string=?,
-    ~connection: Connection.t=?,
+    ~connection: string=?,
     ~pool: Pool.t=?,
     ~migrations: Migrations.t=?,
     ~seeds: seeds=?,


### PR DESCRIPTION
I was looking for a way to pass `Sys.getenv("DATABASE_URL")` for `connection` like you can in the node knex. It appears that is not currently possible. However, based on the name `makeStringConnection`, I'm assuming `~connection` is supposed to be a string not a `Connection`? The way it's currently written there doesn't appear to be a difference between `make` and `makeStringConnection`. Is this correct? Also, n.b. I didn't test this or anything, just made the change and opened the PR. Not sure what I'd test against anyway ;).